### PR TITLE
XSS fix on `?redirect_url` parameter

### DIFF
--- a/ahmia/search/views.py
+++ b/ahmia/search/views.py
@@ -27,6 +27,16 @@ def onion_redirect(request):
 
     redirect_url = request.GET.get('redirect_url', '')
     search_term = request.GET.get('search_term', '')
+    
+    #Checks for "malicious" URI-schemes that could lead to XSS
+    original_redirect_url = redirect_url
+    redirect_url = redirect_url.replace('javascript:', '').replace('data:', '')
+    
+    #Malicious user is redirected on a 403 error page 
+    #if the previous checks replace a malicious URI-scheme
+    if original_redirect_url != redirect_url:
+        answer = "Bad request: undefined URI-scheme provided"
+        return HttpResponseForbidden(answer)
 
     if not redirect_url or not search_term:
         answer = "Bad request: no GET parameter URL."


### PR DESCRIPTION
Changes done after the `XSS report` forwarded yesterday to @juhanurmi

XSS on redirection can be avoided simply checking if the provided `URI-scheme` is valid or not.
In this case (XSS on redirection), the context can be limited to only 2 schemes: `javascript:` and `data:`. 
Replacing those 2 strings, and redirecting the malicious user on a `403 Forbidden` error page, makes harder exploit the highlighted vulnerability :).

Note: The changes don't implement a WAF/similar, but simply replaces the malicious `URI-schemes` in order to avoid that any attacker could utilize them.

Fix implemented by @Mik317 (https://hackerone.com/mik317) after discovering the issue in date `27-06-2019`.